### PR TITLE
UserSubscriptionManager:getManager() return none Type because $user instance of Proxies\__CG__\ object

### DIFF
--- a/src/Registry/WebPushManagerRegistry.php
+++ b/src/Registry/WebPushManagerRegistry.php
@@ -67,7 +67,8 @@ final class WebPushManagerRegistry implements ContainerAwareInterface
         }
 
         if (is_object($userClass)) {
-            $userClass = get_class($userClass);
+            $em = $this->container->get('doctrine')->getEntityManager();
+            $userClass = $em->getMetadataFactory()->getMetadataFor(get_class($userClass))->getName();
         }
 
         foreach ($this->associations as $association) {


### PR DESCRIPTION
The method return nothing because the variable passed could be instance of Proxies\__CG__\ object.