### PR TITLE
BentoolWebPushClient duplicated on browser

### DIFF
--- a/doc/03 - Configuration.md
+++ b/doc/03 - Configuration.md
@@ -32,7 +32,7 @@ Insert this snippet in the templates where your user is logged in:
 <script>
     var webpush = new BenToolsWebPushClient({
         serverKey: '{{ bentools_pusher.server_key | e('js') }}',
-        url: '{{ path('bentools_webpush.subscription') }}'
+        url: '{{ url('bentools_webpush.subscription') }}'
     });
 </script>
 ```


### PR DESCRIPTION
`path` function return a relative url, use `url` function instead which return an absolute url 