### PR TITLE
Fixed Symfony 5.4 deprecations and missing GuzzleHttp\Psr\stream_for() function

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -8,7 +8,7 @@ use Symfony\Component\HttpKernel\Kernel;
 
 class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         if (Kernel::MAJOR_VERSION < 4) {
             $treeBuilder = new TreeBuilder();

--- a/src/DependencyInjection/WebPushExtension.php
+++ b/src/DependencyInjection/WebPushExtension.php
@@ -32,7 +32,7 @@ class WebPushExtension extends Extension
     /**
      * {@inheritdoc}
      */
-    public function getAlias()
+    public function getAlias(): string
     {
         return 'bentools_webpush';
     }

--- a/src/Sender/RequestBuilder.php
+++ b/src/Sender/RequestBuilder.php
@@ -6,7 +6,6 @@ use Base64Url\Base64Url;
 use BenTools\WebPushBundle\Model\Message\PushMessage;
 use BenTools\WebPushBundle\Model\Subscription\UserSubscriptionInterface;
 use GuzzleHttp\Psr7\Request;
-use function GuzzleHttp\Psr7\stream_for;
 use GuzzleHttp\Psr7\Uri;
 use Minishlink\WebPush\Encryption;
 use Minishlink\WebPush\Utils;
@@ -56,7 +55,7 @@ final class RequestBuilder
             $content = $encryptionContentCodingHeader.$encrypted['cipherText'];
 
             return $request
-                ->withBody(stream_for($content))
+                ->withBody(\GuzzleHttp\Psr7\Utils::streamFor($content))
                 ->withHeader('Content-Length', Utils::safeStrlen($content));
         }
 


### PR DESCRIPTION
**Fixed Symfony 5.4 deprecations:**
- added return type hints

**missing GuzzleHttp\Psr\stream_for() function:**
- migrated "stream_for()" to new GuzzleHttp\PSR7 static Utils API