### PR TITLE
Fixed Symfony 5.4 LTS deprecations

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -8,7 +8,7 @@ use Symfony\Component\HttpKernel\Kernel;
 
 class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         if (Kernel::MAJOR_VERSION < 4) {
             $treeBuilder = new TreeBuilder();

--- a/src/DependencyInjection/WebPushExtension.php
+++ b/src/DependencyInjection/WebPushExtension.php
@@ -32,7 +32,7 @@ class WebPushExtension extends Extension
     /**
      * {@inheritdoc}
      */
-    public function getAlias()
+    public function getAlias(): string
     {
         return 'bentools_webpush';
     }


### PR DESCRIPTION
Fixed 2 deprecations:

- "Method "Symfony\Component\DependencyInjection\Extension\Extension::getAlias()" might add "string" as a native return type declaration in the future. Do the same in child class "BenTools\WebPushBundle\DependencyInjection\WebPushExtension" now to avoid errors or add an explicit @return annotation to suppress this message."

- "Method "Symfony\Component\Config\Definition\ConfigurationInterface::getConfigTreeBuilder()" might add "TreeBuilder" as a native return type declaration in the future. Do the same in implementation "BenTools\WebPushBundle\DependencyInjection\Configuration" now to avoid errors or add an explicit @return annotation to suppress this message."