### PR TITLE
Fixed PHP Deprecations (ArrayAccess interface)

### DIFF
--- a/src/Model/Message/PushNotification.php
+++ b/src/Model/Message/PushNotification.php
@@ -116,7 +116,7 @@ final class PushNotification implements JsonSerializable, ArrayAccess
      *
      * @since 5.0.0
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return array_key_exists($offset, $this->options);
     }

--- a/src/Model/Message/PushNotification.php
+++ b/src/Model/Message/PushNotification.php
@@ -173,7 +173,7 @@ final class PushNotification implements JsonSerializable, ArrayAccess
      *
      * @since 5.0.0
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->options[$offset]);
     }

--- a/src/Model/Message/PushNotification.php
+++ b/src/Model/Message/PushNotification.php
@@ -155,7 +155,7 @@ final class PushNotification implements JsonSerializable, ArrayAccess
      *
      * @since 5.0.0
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->options[$offset] = $value;
     }


### PR DESCRIPTION
This PR fixes the following three deprecations:

* Deprecated: Return type of BenTools\WebPushBundle\Model\Message\PushNotification::offsetExists($offset) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice"

* Deprecated: Return type of BenTools\WebPushBundle\Model\Message\PushNotification::offsetUnset($offset) should either be compatible with ArrayAccess::offsetUnset(mixed $offset): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice"

* Deprecated: Return type of BenTools\WebPushBundle\Model\Message\PushNotification::offsetSet($offset, $value) should either be compatible with ArrayAccess::offsetSet(mixed $offset, mixed $value): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice"