### PR TITLE
Just a slim update

### DIFF
--- a/src/Sender/PushMessageSender.php
+++ b/src/Sender/PushMessageSender.php
@@ -104,7 +104,7 @@ class PushMessageSender implements PushMessagerSenderInterface
             ;
         }
 
-        $promise = Promise\settle($promises)
+        $promise = Promise\Utils::settle($promises)
             ->then(function ($results) {
                 foreach ($results as $subscriptionHash => $promise) {
                     yield $subscriptionHash => $promise['value'] ?? $promise['reason'];


### PR DESCRIPTION
Hi, 
after updating packages I got exception from Promise/settle call.

Not digging to deep I stumbled over https://docs.aws.amazon.com/aws-sdk-php/v3/api/function-GuzzleHttp.Promise.settle.html which indicates a deprecation.

Just replaced the line - nothing big.
Did quick test and no more problems.
