### PR TITLE
feat(42): Prepare for the next Symfony version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,21 +17,21 @@
         "ext-openssl": "*",
         "guzzlehttp/guzzle": "~6.0|~7.0",
         "minishlink/web-push": "~4.0|~5.0|~6.0|~7.0",
-        "symfony/http-kernel": "~3.0|~4.0|~5.0|~6.0"
+        "symfony/http-kernel": "~5.3|~6.0"
     },
     "require-dev": {
         "bentools/doctrine-static": "1.0.x-dev",
-        "doctrine/dbal": "~2.5 <=2.9",
+        "doctrine/dbal": ">=2.5|~3",
         "nyholm/symfony-bundle-test": "~1.8",
         "phpunit/phpunit": "~5.0|~6.0|~7.0|~8.0|~9.0",
-        "symfony/config": "~4.0|~5.0|~6.0",
-        "symfony/dependency-injection": "~3.0|~4.0|~5.0|~6.0",
-        "symfony/framework-bundle": "~3.0|~4.0|~5.0|~6.0",
-        "symfony/http-foundation": "~3.0|~4.0|~5.0|~6.0",
-        "symfony/routing": "~3.0|~4.0|~5.0|~6.0",
-        "symfony/security": "~3.0|~4.0|~5.0|~6.0",
-        "symfony/var-dumper": "~3.0|~4.0|~5.0|~6.0",
-        "symfony/yaml": "~3.0|~4.0|~5.0|~6.0",
+        "symfony/config": "~5.3|~6.0",
+        "symfony/dependency-injection": "~5.3|~6.0",
+        "symfony/framework-bundle": "~5.3|~6.0",
+        "symfony/http-foundation": "~5.3|~6.0",
+        "symfony/routing": "~5.3|~6.0",
+        "symfony/security-bundle": "~5.3|~6.0",
+        "symfony/var-dumper": "~5.3|~6.0",
+        "symfony/yaml": "~5.3|~6.0",
         "twig/twig": "~1.0|~2.0"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,31 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.1/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
-         cacheResult ="false"
->
-    <php>
-        <ini name="error_reporting" value="-1" />
-        <env name="KERNEL_CLASS" value="BenTools\WebPushBundle\Tests\Classes\TestKernel" />
-        <env name="APP_ENV" value="test" />
-        <env name="APP_DEBUG" value="1" />
-        <env name="APP_SECRET" value="s$cretf0rt3st" />
-        <env name="SHELL_VERBOSITY" value="-1" />
-    </php>
-
-    <testsuites>
-        <testsuite name="Project Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>src</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php" cacheResult="false">
+  <coverage>
+    <include>
+      <directory>src</directory>
+    </include>
+  </coverage>
+  <php>
+    <ini name="error_reporting" value="-1"/>
+    <env name="KERNEL_CLASS" value="BenTools\WebPushBundle\Tests\Classes\TestKernel"/>
+    <env name="APP_ENV" value="test"/>
+    <env name="APP_DEBUG" value="1"/>
+    <env name="APP_SECRET" value="s$cretf0rt3st"/>
+    <env name="SHELL_VERBOSITY" value="-1"/>
+  </php>
+  <testsuites>
+    <testsuite name="Project Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Command/WebPushGenerateKeysCommand.php
+++ b/src/Command/WebPushGenerateKeysCommand.php
@@ -4,25 +4,15 @@ namespace BenTools\WebPushBundle\Command;
 
 use Minishlink\WebPush\VAPID;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\HttpKernel\Kernel;
 
+#[AsCommand(name:"webpush:generate:keys", description:"Generate your VAPID keys for bentools/webpush.")]
 final class WebPushGenerateKeysCommand extends Command
 {
-    protected static $defaultName = 'webpush:generate:keys';
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function configure()
-    {
-        $this
-            ->setName('webpush:generate:keys')
-            ->setDescription('Generate your VAPID keys for bentools/webpush.');
-    }
-
     /**
      * {@inheritdoc}
      * @throws \ErrorException
@@ -36,7 +26,7 @@ final class WebPushGenerateKeysCommand extends Command
         $io->writeln(sprintf('Your private key is: <info>%s</info>', $keys['privateKey']));
         $io->newLine(2);
 
-        if (-1 === version_compare(Kernel::VERSION, 4)) {
+        if (-1 === version_compare(Kernel::VERSION, '4')) {
             $io->writeln('Update <info>app/config/config.yml</info>:');
             $io->newLine(1);
             $io->writeln('<info># app/config/config.yml</info>');

--- a/src/Sender/PushMessageSender.php
+++ b/src/Sender/PushMessageSender.php
@@ -16,7 +16,7 @@ use Psr\Http\Message\ResponseInterface;
 class PushMessageSender implements PushMessagerSenderInterface
 {
     /**
-     * @var Client
+     * @var ClientInterface
      */
     private $client;
 

--- a/src/Sender/RequestBuilder.php
+++ b/src/Sender/RequestBuilder.php
@@ -31,7 +31,7 @@ final class RequestBuilder
     ): RequestInterface {
         $request = new Request('POST', $subscription->getEndpoint());
         $request = $this->withOptionalHeaders($request, $message);
-        $request = $request->withHeader('TTL', $ttl);
+        $request = $request->withHeader('TTL', (string) $ttl);
 
         if (null !== $message->getPayload() && null !== $subscription->getPublicKey() && null !== $subscription->getAuthToken()) {
             $request = $request
@@ -57,11 +57,11 @@ final class RequestBuilder
 
             return $request
                 ->withBody(GuzzleUtils::streamFor($content))
-                ->withHeader('Content-Length', Utils::safeStrlen($content));
+                ->withHeader('Content-Length', (string) Utils::safeStrlen($content));
         }
 
         return $request
-            ->withHeader('Content-Length', 0);
+            ->withHeader('Content-Length', '0');
     }
 
     /**

--- a/tests/Classes/TestKernel.php
+++ b/tests/Classes/TestKernel.php
@@ -26,7 +26,7 @@ final class TestKernel extends Kernel
         $this->logDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . $uniqid . DIRECTORY_SEPARATOR . 'logs';
     }
 
-    public function registerBundles()
+    public function registerBundles(): \Traversable|array
     {
         return [
             new FrameworkBundle(),
@@ -34,7 +34,7 @@ final class TestKernel extends Kernel
         ];
     }
 
-    protected function configureRoutes(RouteCollectionBuilder $routes)
+    protected function configureRoutes(): void
     {
     }
 
@@ -58,12 +58,12 @@ final class TestKernel extends Kernel
         $c->addCompilerPass(new PublicServicePass());
     }
 
-    public function getCacheDir()
+    public function getCacheDir(): string
     {
         return $this->cacheDir;
     }
 
-    public function getLogDir()
+    public function getLogDir(): string
     {
         return $this->logDir;
     }

--- a/tests/Classes/TestUser.php
+++ b/tests/Classes/TestUser.php
@@ -21,8 +21,9 @@ final class TestUser implements UserInterface
         return $this->userName;
     }
 
-    public function getRoles()
+    public function getRoles(): array
     {
+        return [];
     }
 
     public function getPassword()
@@ -35,5 +36,10 @@ final class TestUser implements UserInterface
 
     public function eraseCredentials()
     {
+    }
+
+    public function getUserIdentifier(): string
+    {
+        return $this->userName;
     }
 }


### PR DESCRIPTION
Fixing command deprecation requires AsCommand, which breaks support for SF < 5.3