### PR TITLE
maintenance : updated dependencies for security and PHP constraints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,14 +5,14 @@ on:
 
 env:
   COMPOSER_FLAGS: "--prefer-stable"
-  
+
 jobs:
   ci_job:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
         operating-system: ['ubuntu-latest']
-        php-versions: ['8.1', '8.2']
+        php-versions: ['8.1', '8.2', '8.3']
 
     steps:
       - name: Checkout
@@ -29,3 +29,13 @@ jobs:
 
       - name: Process the tests
         run: vendor/bin/phpunit
+
+      - name: Tests with lowest posible packages
+        run: |
+          composer update $COMPOSER_FLAGS --no-interaction --prefer-dist --prefer-lowest --no-progress --ansi
+          vendor/bin/phpunit
+
+      - name: Tests with highest posible packages
+        run: |
+          composer update $COMPOSER_FLAGS --no-interaction --prefer-dist --prefer-highest --no-progress --ansi
+          vendor/bin/phpunit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,12 +30,8 @@ jobs:
       - name: Process the tests
         run: vendor/bin/phpunit
 
-      - name: Tests with lowest posible packages
-        run: |
-          composer update $COMPOSER_FLAGS --no-interaction --prefer-dist --prefer-lowest --no-progress --ansi
-          vendor/bin/phpunit
-
-      - name: Tests with highest posible packages
-        run: |
-          composer update $COMPOSER_FLAGS --no-interaction --prefer-dist --prefer-highest --no-progress --ansi
-          vendor/bin/phpunit
+# Too much conflict with PHPUnit and old low package versions
+#      - name: Tests with lowest posible packages
+#        run: |
+#          composer update $COMPOSER_FLAGS --no-interaction --prefer-dist --prefer-lowest --no-progress --ansi
+#          vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "bentools/doctrine-static": "1.0.x-dev",
         "doctrine/dbal": "~2.5 <=2.9",
         "nyholm/symfony-bundle-test": "~1.8",
-        "phpunit/phpunit": "~8.0|~9.0",
+        "phpunit/phpunit": "^8.5.38|~9.0",
         "symfony/config": "~4.0|~5.0|~6.0",
         "symfony/dependency-injection": "~3.0|~4.0|~5.0|~6.0",
         "symfony/framework-bundle": "~3.0|~4.0|~5.0|~6.0",
@@ -32,7 +32,8 @@
         "symfony/security": "~3.0|~4.0|~5.0|~6.0",
         "symfony/var-dumper": "~3.0|~4.0|~5.0|~6.0",
         "symfony/yaml": "~3.0|~4.0|~5.0|~6.0",
-        "twig/twig": "~1.0|~2.0"
+        "twig/twig": "~1.0|~2.0",
+        "web-token/jwt-util-ecc": ">=2.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -15,15 +15,15 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-openssl": "*",
-        "guzzlehttp/guzzle": "~6.0|~7.0",
-        "minishlink/web-push": "~4.0|~5.0|~6.0|~7.0",
-        "symfony/http-kernel": "~3.0|~4.0|~5.0|~6.0"
+        "guzzlehttp/guzzle": "^6.5.8|^7.4",
+        "minishlink/web-push": "~6.0|~7.0|~8.0",
+        "symfony/http-kernel": "^4.4.50|^5.4.20|^6.0"
     },
     "require-dev": {
         "bentools/doctrine-static": "1.0.x-dev",
         "doctrine/dbal": "~2.5 <=2.9",
         "nyholm/symfony-bundle-test": "~1.8",
-        "phpunit/phpunit": "~5.0|~6.0|~7.0|~8.0|~9.0",
+        "phpunit/phpunit": "~8.0|~9.0",
         "symfony/config": "~4.0|~5.0|~6.0",
         "symfony/dependency-injection": "~3.0|~4.0|~5.0|~6.0",
         "symfony/framework-bundle": "~3.0|~4.0|~5.0|~6.0",

--- a/src/Command/WebPushGenerateKeysCommand.php
+++ b/src/Command/WebPushGenerateKeysCommand.php
@@ -3,12 +3,14 @@
 namespace BenTools\WebPushBundle\Command;
 
 use Minishlink\WebPush\VAPID;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\HttpKernel\Kernel;
 
+#[AsCommand('webpush:generate:keys')]
 final class WebPushGenerateKeysCommand extends Command
 {
     protected static $defaultName = 'webpush:generate:keys';


### PR DESCRIPTION
This is mostly a cleaning of the composer file.

## Security update

guzzlehttp/guzzle upgrade to 6.5 or 7.4 : https://devhub.checkmarx.com/cve-details/CVE-2022-31090/
symfony/http-kernel upgrade to : https://devhub.checkmarx.com/cve-details/CVE-2022-24894/

## Incompatibility

minishlink/web-push: Version 4 and 5 are not possible due to PHP version constraints.
	* https://github.com/web-push-libs/web-push-php/blob/v4.0.2/composer.json
	* https://github.com/web-push-libs/web-push-php/blob/v5.2.5/composer.json 
phpunit/phpunit: versions 5 to 7 are not posible due to PHP version constraints.