### PR TITLE
chore: add Symfony 7 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,11 @@ This bundle is just the back-end part of the subscription process. For the front
 
 ### Composer is your friend:
 
-PHP7.1+ is required.
+PHP8.1+ is required.
 
 ```bash
 composer require bentools/webpush-bundle
 ```
-
-If you're using Symfony 3, add the bundle to your kernel. With Symfony Flex, this should be done automatically.
 
 ⚠️ _We aren't on stable version yet - expect some changes._
 

--- a/composer.json
+++ b/composer.json
@@ -15,25 +15,23 @@
         "ext-json": "*",
         "ext-mbstring": "*",
         "ext-openssl": "*",
-        "guzzlehttp/guzzle": "^6.5.8|^7.4",
-        "minishlink/web-push": "~6.0|~7.0|~8.0",
-        "symfony/http-kernel": "^4.4.50|^5.4.20|^6.0"
+        "guzzlehttp/guzzle": "^6.5.8 || ^7.4",
+        "minishlink/web-push": "^6.0.7 || ^7.0 || ^8.0",
+        "symfony/http-kernel": "^5.4.20 || ^6.0 || ^7.0"
     },
     "require-dev": {
         "bentools/doctrine-static": "1.0.x-dev",
-        "doctrine/dbal": "~2.5 <=2.9",
-        "nyholm/symfony-bundle-test": "~1.8",
-        "phpunit/phpunit": "^8.5.38|~9.0",
-        "symfony/config": "~4.0|~5.0|~6.0",
-        "symfony/dependency-injection": "~3.0|~4.0|~5.0|~6.0",
-        "symfony/framework-bundle": "~3.0|~4.0|~5.0|~6.0",
-        "symfony/http-foundation": "~3.0|~4.0|~5.0|~6.0",
-        "symfony/routing": "~3.0|~4.0|~5.0|~6.0",
-        "symfony/security": "~3.0|~4.0|~5.0|~6.0",
-        "symfony/var-dumper": "~3.0|~4.0|~5.0|~6.0",
-        "symfony/yaml": "~3.0|~4.0|~5.0|~6.0",
-        "twig/twig": "~1.0|~2.0",
-        "web-token/jwt-util-ecc": ">=2.1"
+        "doctrine/dbal": "^2.9 || ^3.0",
+        "phpunit/phpunit": "^9.0",
+        "symfony/config": "^5.4 || ^6.0 || ^7.0",
+        "symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0",
+        "symfony/framework-bundle": "^5.4 || ^6.0 || ^7.0",
+        "symfony/http-foundation": "^5.4 || ^6.0 || ^7.0",
+        "symfony/routing": "^5.4 || ^6.0 || ^7.0",
+        "symfony/security-core": "^5.4 || ^6.0 || ^7.0",
+        "symfony/var-dumper": "^5.4 || ^6.0 || ^7.0",
+        "symfony/yaml": "^5.4 || ^6.0 || ^7.0",
+        "twig/twig": "^2.0 || ^3.0"
     },
     "autoload": {
         "psr-4": {
@@ -43,10 +41,7 @@
     "autoload-dev": {
         "psr-4": {
             "BenTools\\WebPushBundle\\Tests\\": "tests"
-        },
-        "files": [
-            "vendor/symfony/var-dumper/Resources/functions/dump.php"
-        ]
+        }
     },
     "config": {
         "sort-packages": true

--- a/doc/02 - The UserSubscription Manager.md
+++ b/doc/02 - The UserSubscription Manager.md
@@ -15,7 +15,7 @@ namespace App\Services;
 use App\Entity\UserSubscription;
 use BenTools\WebPushBundle\Model\Subscription\UserSubscriptionInterface;
 use BenTools\WebPushBundle\Model\Subscription\UserSubscriptionManagerInterface;
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 class UserSubscriptionManager implements UserSubscriptionManagerInterface

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,31 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.1/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          backupGlobals="false"
          colors="true"
-         bootstrap="vendor/autoload.php"
-         cacheResult ="false"
+         bootstrap="tests/bootstrap.php"
+         cacheResult="false"
 >
+    <coverage>
+        <include>
+            <directory>src</directory>
+        </include>
+    </coverage>
     <php>
-        <ini name="error_reporting" value="-1" />
-        <env name="KERNEL_CLASS" value="BenTools\WebPushBundle\Tests\Classes\TestKernel" />
-        <env name="APP_ENV" value="test" />
-        <env name="APP_DEBUG" value="1" />
-        <env name="APP_SECRET" value="s$cretf0rt3st" />
-        <env name="SHELL_VERBOSITY" value="-1" />
+        <ini name="error_reporting" value="-1"/>
+        <env name="KERNEL_CLASS" value="BenTools\WebPushBundle\Tests\Classes\TestKernel"/>
+        <env name="APP_ENV" value="test"/>
+        <env name="APP_DEBUG" value="1"/>
+        <env name="APP_SECRET" value="s$cretf0rt3st"/>
+        <env name="SHELL_VERBOSITY" value="-1"/>
     </php>
-
     <testsuites>
         <testsuite name="Project Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>src</directory>
-        </whitelist>
-    </filter>
 </phpunit>

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -4,19 +4,13 @@ namespace BenTools\WebPushBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
-use Symfony\Component\HttpKernel\Kernel;
 
 class Configuration implements ConfigurationInterface
 {
     public function getConfigTreeBuilder(): TreeBuilder
     {
-        if (Kernel::MAJOR_VERSION < 4) {
-            $treeBuilder = new TreeBuilder();
-            $rootNode = $treeBuilder->root('bentools_webpush');
-        } else {
-            $treeBuilder = new TreeBuilder('bentools_webpush');
-            $rootNode = $treeBuilder->getRootNode();
-        }
+        $treeBuilder = new TreeBuilder('bentools_webpush');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()

--- a/src/WebPushBundle.php
+++ b/src/WebPushBundle.php
@@ -18,7 +18,7 @@ class WebPushBundle extends Bundle
         return new WebPushExtension();
     }
 
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new WebPushCompilerPass());
     }

--- a/tests/BundleTest.php
+++ b/tests/BundleTest.php
@@ -17,31 +17,31 @@ final class BundleTest extends KernelTestCase
     /**
      * @test
      */
-    public function parameters_are_set()
+    public function parameters_are_set(): void
     {
-        $this->assertEquals('this_is_a_private_key', self::$kernel->getContainer()->getParameter('bentools_webpush.vapid_private_key'));
-        $this->assertEquals('this_is_a_public_key', self::$kernel->getContainer()->getParameter('bentools_webpush.vapid_public_key'));
-        $this->assertTrue(self::$kernel->getContainer()->has(UserSubscriptionManagerRegistry::class));
+        $this->assertEquals('this_is_a_private_key', self::getContainer()->getParameter('bentools_webpush.vapid_private_key'));
+        $this->assertEquals('this_is_a_public_key', self::getContainer()->getParameter('bentools_webpush.vapid_public_key'));
+        $this->assertTrue(self::getContainer()->has(UserSubscriptionManagerRegistry::class));
     }
 
     /**
      * @test
      */
-    public function manager_is_found()
+    public function manager_is_found(): void
     {
         // Find by class name
-        $this->assertInstanceOf(TestUserSubscriptionManager::class, self::$kernel->getContainer()->get(UserSubscriptionManagerRegistry::class)->getManager(TestUser::class));
+        $this->assertInstanceOf(TestUserSubscriptionManager::class, self::getContainer()->get(UserSubscriptionManagerRegistry::class)->getManager(TestUser::class));
 
         // Find by object
-        $this->assertInstanceOf(TestUserSubscriptionManager::class, self::$kernel->getContainer()->get(UserSubscriptionManagerRegistry::class)->getManager(new TestUser('foo')));
+        $this->assertInstanceOf(TestUserSubscriptionManager::class, self::getContainer()->get(UserSubscriptionManagerRegistry::class)->getManager(new TestUser('foo')));
     }
 
     /**
      * @test
      */
-    public function unknown_manager_raises_exception()
+    public function unknown_manager_raises_exception(): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        self::$kernel->getContainer()->get(UserSubscriptionManagerRegistry::class)->getManager(Foo::class);
+        self::getContainer()->get(UserSubscriptionManagerRegistry::class)->getManager(Foo::class);
     }
 }

--- a/tests/Classes/TestKernel.php
+++ b/tests/Classes/TestKernel.php
@@ -3,20 +3,18 @@
 namespace BenTools\WebPushBundle\Tests\Classes;
 
 use BenTools\WebPushBundle\WebPushBundle;
-use Nyholm\BundleTest\CompilerPass\PublicServicePass;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
-use Symfony\Component\Routing\RouteCollectionBuilder;
 
 final class TestKernel extends Kernel
 {
     use MicroKernelTrait;
 
-    protected $cacheDir;
-    protected $logDir;
+    protected string $cacheDir;
+    protected string $logDir;
 
     public function __construct(string $environment, bool $debug)
     {
@@ -26,7 +24,7 @@ final class TestKernel extends Kernel
         $this->logDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . $uniqid . DIRECTORY_SEPARATOR . 'logs';
     }
 
-    public function registerBundles()
+    public function registerBundles(): iterable
     {
         return [
             new FrameworkBundle(),
@@ -34,36 +32,27 @@ final class TestKernel extends Kernel
         ];
     }
 
-    protected function configureRoutes(RouteCollectionBuilder $routes)
+    protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader): void
     {
-    }
-
-    protected function configureContainer(ContainerBuilder $c, LoaderInterface $loader)
-    {
-        $c->loadFromExtension('framework', [
+        $container->loadFromExtension('framework', [
             'secret' => getenv('APP_SECRET'),
         ]);
-        $c->loadFromExtension('bentools_webpush', [
+        $container->loadFromExtension('bentools_webpush', [
             'settings' => [
                 'private_key' => 'this_is_a_private_key',
                 'public_key' => 'this_is_a_public_key',
             ]
         ]);
         $loader->load(dirname(__DIR__) . '/Resources/services.yaml');
-
-        if (1 === version_compare(self::VERSION, '4.0')) {
-            $loader->load(dirname(__DIR__) . '/Resources/framework.yaml');
-        }
-
-        $c->addCompilerPass(new PublicServicePass());
+        $loader->load(dirname(__DIR__) . '/Resources/framework.yaml');
     }
 
-    public function getCacheDir()
+    public function getCacheDir(): string
     {
         return $this->cacheDir;
     }
 
-    public function getLogDir()
+    public function getLogDir(): string
     {
         return $this->logDir;
     }

--- a/tests/Classes/TestUser.php
+++ b/tests/Classes/TestUser.php
@@ -6,34 +6,21 @@ use Symfony\Component\Security\Core\User\UserInterface;
 
 final class TestUser implements UserInterface
 {
-    /**
-     * @var string
-     */
-    private $userName;
-
-    public function __construct(string $userName)
+    public function __construct(private string $userName)
     {
-        $this->userName = $userName;
     }
 
-    public function getUsername()
+    public function getUserIdentifier(): string
     {
         return $this->userName;
     }
 
-    public function getRoles()
+    public function getRoles(): array
     {
+        return [];
     }
 
-    public function getPassword()
-    {
-    }
-
-    public function getSalt()
-    {
-    }
-
-    public function eraseCredentials()
+    public function eraseCredentials(): void
     {
     }
 }

--- a/tests/Classes/TestUserSubscription.php
+++ b/tests/Classes/TestUserSubscription.php
@@ -7,47 +7,16 @@ use Symfony\Component\Security\Core\User\UserInterface;
 
 final class TestUserSubscription implements UserSubscriptionInterface
 {
-
-    private $id;
-
-    /**
-     * @var UserInterface
-     */
-    private $user;
-
-    /**
-     * @var string
-     */
-    private $endpoint;
-
-    /**
-     * @var string
-     */
-    private $publicKey;
-
-    /**
-     * @var string
-     */
-    private $authtoken;
-
-    /**
-     * @var string
-     */
-    private $subscriptionHash;
+    private string $id;
 
     public function __construct(
-        UserInterface $user,
-        string $endpoint,
-        string $publicKey,
-        string $authtoken,
-        string $subscriptionHash
+        private UserInterface $user,
+        private string $endpoint,
+        private string $publicKey,
+        private string $authtoken,
+        private string $subscriptionHash
     ) {
-        $this->id = $user->getUsername();
-        $this->user = $user;
-        $this->endpoint = $endpoint;
-        $this->publicKey = $publicKey;
-        $this->authtoken = $authtoken;
-        $this->subscriptionHash = $subscriptionHash;
+        $this->id = $user->getUserIdentifier();
     }
 
     public function getUser(): UserInterface

--- a/tests/Classes/TestUserSubscriptionManager.php
+++ b/tests/Classes/TestUserSubscriptionManager.php
@@ -4,23 +4,13 @@ namespace BenTools\WebPushBundle\Tests\Classes;
 
 use BenTools\WebPushBundle\Model\Subscription\UserSubscriptionInterface;
 use BenTools\WebPushBundle\Model\Subscription\UserSubscriptionManagerInterface;
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\Security\Core\User\UserInterface;
 
 final class TestUserSubscriptionManager implements UserSubscriptionManagerInterface
 {
-    /**
-     * @var ManagerRegistry
-     */
-    private $doctrine;
-
-    /**
-     * UserSubscriptionManager constructor.
-     * @param ManagerRegistry $doctrine
-     */
-    public function __construct(ManagerRegistry $doctrine)
+    public function __construct(private readonly ManagerRegistry $doctrine)
     {
-        $this->doctrine = $doctrine;
     }
 
     /**

--- a/tests/RegistrationTest.php
+++ b/tests/RegistrationTest.php
@@ -22,15 +22,16 @@ final class RegistrationTest extends KernelTestCase
     public function registration_works()
     {
         /** @var ManagerRegistry $persistence */
-        $persistence = self::$kernel->getContainer()->get('doctrine');
-        $registry = self::$kernel->getContainer()->get(UserSubscriptionManagerRegistry::class);
+        $persistence = self::getContainer()->get('doctrine');
+        $registry = self::getContainer()->get(UserSubscriptionManagerRegistry::class);
         $em = $persistence->getManagerForClass(TestUser::class);
         $bob = new TestUser('bob');
         $em->persist($bob);
         $em->flush();
         $this->assertNotNull($em->find(TestUser::class, 'bob'));
 
-        $register = self::$kernel->getContainer()->get(RegisterSubscriptionAction::class);
+        /** @var RegisterSubscriptionAction $register */
+        $register = self::getContainer()->get(RegisterSubscriptionAction::class);
 
         $rawSubscriptionData = [
             'subscription' => [

--- a/tests/Resources/framework.yaml
+++ b/tests/Resources/framework.yaml
@@ -1,3 +1,4 @@
 framework:
+    test: true
     cache:
         default_pdo_provider: ~

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace global {
+    require dirname(__DIR__) . '/vendor/autoload.php';
+}
+
+// Those namespace overrides allow using https://github.com/bpolaszek/doctrine-static with a more actual Doctrine version
+namespace Doctrine\Common\Persistence {
+
+    use Doctrine\Persistence\ManagerRegistry as NewManagerRegistry;
+    use Doctrine\Persistence\ObjectManager as NewObjectManager;
+    use Doctrine\Persistence\ObjectRepository as NewObjectRepository;
+
+    if (!interface_exists(ManagerRegistry::class)) {
+        interface ManagerRegistry extends NewManagerRegistry
+        {
+        }
+    }
+
+    if (!interface_exists(ObjectManager::class)) {
+        interface ObjectManager extends NewObjectManager
+        {
+        }
+    }
+
+    if (!interface_exists(ObjectRepository::class)) {
+        interface ObjectRepository extends NewObjectRepository
+        {
+        }
+    }
+
+}


### PR DESCRIPTION
Fixes https://github.com/bpolaszek/webpush-bundle/issues/49

Nothing changed in the src dir, except removing of sf4 dedicated blocs.

I've updated some dev vendors, but `--prefer-lowest` deps are still not usable, especially because of `bentools/doctrine-static` old doctrine requirement (I've added some `Doctrine\Common\Persistence ` old interfaces stubs in order to keep using it).