### PR TITLE
fix: add return type to `configure` method of `WebPushGenerateKeysCommand` 

### DIFF
--- a/src/Command/WebPushGenerateKeysCommand.php
+++ b/src/Command/WebPushGenerateKeysCommand.php
@@ -18,7 +18,7 @@ final class WebPushGenerateKeysCommand extends Command
     /**
      * {@inheritdoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('webpush:generate:keys')


### PR DESCRIPTION
```
Method "Symfony\Component\Console\Command\Command::configure()" might add "void" as a native return type declaration in the future. Do the same in child class "BenTools\WebPushBundle\Command\WebPushGenerateKeysCommand" now to avoid errors or add an explicit @return annotation to suppress this message.
```